### PR TITLE
[마이페이지] 오픈소스 라이선스 View 구현

### DIFF
--- a/Eoljuga/Eoljuga.xcodeproj/project.pbxproj
+++ b/Eoljuga/Eoljuga.xcodeproj/project.pbxproj
@@ -86,6 +86,8 @@
 		D88295FC292A4452005B4273 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88295FB292A4452005B4273 /* HTTPMethod.swift */; };
 		D88295FE292A4459005B4273 /* URLSessionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88295FD292A4459005B4273 /* URLSessionService.swift */; };
 		D8829600292A44B9005B4273 /* FireStoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88295FF292A44B9005B4273 /* FireStoreService.swift */; };
+		D8C3866A292B4AEF005A2563 /* OpenSourceLicenseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C38669292B4AEF005A2563 /* OpenSourceLicenseViewController.swift */; };
+		D8C3866C292B4B0B005A2563 /* OpenSourceLicenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C3866B292B4B0B005A2563 /* OpenSourceLicenseView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -163,6 +165,8 @@
 		D88295FB292A4452005B4273 /* HTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		D88295FD292A4459005B4273 /* URLSessionService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionService.swift; sourceTree = "<group>"; };
 		D88295FF292A44B9005B4273 /* FireStoreService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FireStoreService.swift; sourceTree = "<group>"; };
+		D8C38669292B4AEF005A2563 /* OpenSourceLicenseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSourceLicenseViewController.swift; sourceTree = "<group>"; };
+		D8C3866B292B4B0B005A2563 /* OpenSourceLicenseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSourceLicenseView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -521,6 +525,7 @@
 			children = (
 				D8494D452927C97E008157F1 /* MyPageView.swift */,
 				D8494D512927D085008157F1 /* MyPageProfileView.swift */,
+				D8C3866B292B4B0B005A2563 /* OpenSourceLicenseView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -529,6 +534,7 @@
 			isa = PBXGroup;
 			children = (
 				B50A27BB29279F5D00DF3E1F /* MyPageViewController.swift */,
+				D8C38669292B4AEF005A2563 /* OpenSourceLicenseViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -730,8 +736,10 @@
 				B50A27F529279F5D00DF3E1F /* AppCoordinator.swift in Sources */,
 				B50A27F929279F5D00DF3E1F /* TabBarPage.swift in Sources */,
 				3B061FE2292926DA00BFA71D /* SignUpViewModel.swift in Sources */,
+				D8C3866C292B4B0B005A2563 /* OpenSourceLicenseView.swift in Sources */,
 				B50A27DB29279F5D00DF3E1F /* Colors+Generated.swift in Sources */,
 				1459C3BC2929150200FA885D /* FeedCellType.swift in Sources */,
+				D8C3866A292B4AEF005A2563 /* OpenSourceLicenseViewController.swift in Sources */,
 				B50A27D929279F5D00DF3E1F /* UIStackView+addArrangedSubviews.swift in Sources */,
 				3B061FD82928CC5600BFA71D /* SignUpDomainViewController.swift in Sources */,
 				D88295ED292A43E2005B4273 /* UserDTO.swift in Sources */,

--- a/Eoljuga/Eoljuga/Scene/Tab/MyPage/View/OpenSourceLicenseView.swift
+++ b/Eoljuga/Eoljuga/Scene/Tab/MyPage/View/OpenSourceLicenseView.swift
@@ -1,0 +1,94 @@
+//
+//  OpenSourceLicenseView.swift
+//  Eoljuga
+//
+//  Created by neuli on 2022/11/21.
+//
+
+import UIKit
+
+final class OpenSourceLicenseView: UIView {
+
+    // MARK: - Properties
+
+    private let openSources: [(name: String, link: String)] = [
+        ("firebase-ios-sdk", "https://github.com/firebase/firebase-ios-sdk"),
+        ("Then", "https://github.com/devxoul/Then"),
+        ("SnapKit", "https://github.com/SnapKit/SnapKit")
+    ]
+
+    private lazy var titleLabel = UILabel().then {
+        $0.text = "오픈소스 라이선스"
+        $0.textColor = .black
+        $0.font = .extraBold24
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Methods
+
+    private func configureUI() {
+        addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(120)
+            make.horizontalEdges.equalToSuperview().inset(Constant.space16)
+        }
+
+        let openSourcesStackView = UIStackView(
+            arrangedSubviews: openSources.map {
+                openSourceStackView(
+                    nameLabel: openSourceNameLabel(name: $0.name),
+                    linkButton: openSourceLinkLabel(link: $0.link)
+                )
+            }
+        ).then {
+            $0.axis = .vertical
+            $0.distribution = .equalSpacing
+            $0.alignment = .fill
+            $0.spacing = Constant.space16.cgFloat
+        }
+
+        addSubview(openSourcesStackView)
+        openSourcesStackView.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(Constant.space24)
+            make.horizontalEdges.equalToSuperview().inset(Constant.space16)
+        }
+    }
+
+    private func openSourceNameLabel(name: String) -> UILabel {
+        return UILabel().then {
+            $0.text = name
+            $0.textColor = .black
+            $0.font = .regular16
+        }
+    }
+
+    private func openSourceLinkLabel(link: String) -> UIButton {
+        return UIButton().then {
+            $0.setTitle(link, for: .normal)
+            $0.setTitleColor(.main, for: .normal)
+            $0.contentHorizontalAlignment = .left
+            $0.backgroundColor = .clear
+            $0.titleLabel?.font = .regular12
+        }
+    }
+
+    private func openSourceStackView(
+        nameLabel: UILabel,
+        linkButton: UIButton
+    ) -> UIStackView {
+        return UIStackView(arrangedSubviews: [nameLabel, linkButton]).then {
+            $0.axis = .vertical
+            $0.distribution = .equalSpacing
+            $0.alignment = .fill
+            $0.spacing = Constant.space8.cgFloat
+        }
+    }
+}

--- a/Eoljuga/Eoljuga/Scene/Tab/MyPage/ViewController/OpenSourceLicenseViewController.swift
+++ b/Eoljuga/Eoljuga/Scene/Tab/MyPage/ViewController/OpenSourceLicenseViewController.swift
@@ -1,0 +1,31 @@
+//
+//  OpenSourceLicenseViewController.swift
+//  Eoljuga
+//
+//  Created by neuli on 2022/11/21.
+//
+
+import UIKit
+
+final class OpenSourceLicenseViewController: UIViewController {
+
+    // MARK: - Properties
+
+    private var openSourceLicenseView: OpenSourceLicenseView {
+        guard let view = view as? OpenSourceLicenseView else {
+            return OpenSourceLicenseView()
+        }
+        return view
+    }
+
+    // MARK: - Life Cycle
+
+    override func loadView() {
+        view = openSourceLicenseView
+    }
+
+    override func viewDidLoad() {
+    }
+
+    // MARK: - Methods
+}


### PR DESCRIPTION
## 관련 이슈
- close #72 

## 내용
- (오픈소스이름, 링크 주소) 마다 label과 button 스택뷰를 만들어 View에 추가해주었습니다.
- 오픈소스가 세개뿐이라 굳이 테이블뷰로 만들지 않았습니다.
![image](https://user-images.githubusercontent.com/39167842/202988188-a0b6bd41-5e9d-4b1a-95ce-a9326cac4f77.png)


## 리뷰어가 확인할 사항
- 사파리로 링크 타고 들어가는 부분은 마이페이지 코디네이터 작업에서 할 예정입니다.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
